### PR TITLE
Removed "SNAPSHOT" from version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <groupId>com.risevision.monitoring</groupId>
     <artifactId>monitoring-filter</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
@alex-deaconu please review.

I forgot to remove "SNAPSHOT" from the version (it wasn't there before the migration) and as a result JAR went to `snapshot` branch of `mvn-repo` instead of `release` branch.